### PR TITLE
feat: show [redacted] for SecureString values in tree output

### DIFF
--- a/src/ssmtree/cli.py
+++ b/src/ssmtree/cli.py
@@ -179,7 +179,7 @@ def main(
         ]
         click.echo(json.dumps(data, indent=2, default=str))
     else:
-        rich_tree = render_tree(tree, show_values=show_values)
+        rich_tree = render_tree(tree, show_values=show_values, decrypt=decrypt)
         console.print(rich_tree)
 
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -31,6 +31,10 @@
 ## Phase 5: CI
 - [x] `.github/workflows/ci.yml` — lint + test on push/PR
 
+## Backlog
+
+- [x] Show `[redacted]` for `SecureString` parameter values in tree output to make it clear to the user that the value is sensitive and not displayed (unless `--decrypt` is passed)
+
 ## CLI Usage
 
 ```bash


### PR DESCRIPTION
## Summary

- SecureString parameter values are now always displayed as `[redacted]` (dim red) in the tree output when `--decrypt` is not passed
- Fixes a latent bug where the previous `***` guard relied on `param.value == ""`, which never fires in practice — the SSM API returns encrypted ciphertext when `WithDecryption=False`, not an empty string
- The `decrypt` flag is now threaded from the CLI through `render_tree` → `_add_node` → `_param_label` so the formatter has authoritative knowledge of whether decryption was requested
- `--decrypt --show-values` continues to reveal the actual decrypted value as expected

## Test plan

- [x] `test_secure_string_shows_redacted_without_decrypt` — ciphertext is replaced with `[redacted]`, raw value not shown
- [x] `test_secure_string_hides_value_entirely_when_show_values_false` — neither `[redacted]` nor ciphertext shown when values hidden
- [x] `test_secure_string_shows_value_when_decrypted` — actual value shown when `decrypt=True`, no `[redacted]`
- [x] All 104 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)