### PR TITLE
feat: redact SecureString values in diff table output

### DIFF
--- a/src/ssmtree/cli.py
+++ b/src/ssmtree/cli.py
@@ -274,7 +274,9 @@ def diff_cmd(
         if not added and not removed and not changed:
             console.print("[bold green]Namespaces are identical.[/]")
         else:
-            table = render_diff(added, removed, changed, path1, path2, show_values=show_values, decrypt=decrypt)
+            table = render_diff(
+                added, removed, changed, path1, path2, show_values=show_values, decrypt=decrypt
+            )
             console.print(table)
 
 

--- a/src/ssmtree/formatters.py
+++ b/src/ssmtree/formatters.py
@@ -142,7 +142,9 @@ def render_diff(
     for old, new in sorted(changed, key=lambda pair: pair[0].path):
         rel = _relative(old.path, path1)
         if show_values:
-            table.add_row("changed", rel, Text(_display_value(old, decrypt)), Text(_display_value(new, decrypt)))
+            old_val = Text(_display_value(old, decrypt))
+            new_val = Text(_display_value(new, decrypt))
+            table.add_row("changed", rel, old_val, new_val)
         else:
             table.add_row("changed", rel)
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -160,7 +160,9 @@ class TestRenderDiff:
         added = _param("/b/token", value="AQICAHiA==", type_="SecureString")
         old = _param("/a/key", value="AQICAHiB==", type_="SecureString")
         new = _param("/b/key", value="AQICAHiC==", type_="SecureString")
-        table = render_diff([added], [removed], [(old, new)], "/a", "/b", show_values=True, decrypt=False)
+        table = render_diff(
+            [added], [removed], [(old, new)], "/a", "/b", show_values=True, decrypt=False
+        )
         output = _render_to_str(table)
         assert output.count("[redacted]") == 4
         assert "AQICAHiR==" not in output


### PR DESCRIPTION
## Summary

- `ssmtree diff --show-values` was leaking encrypted ciphertext for `SecureString` parameters in the table. Now `render_diff` accepts a `decrypt` flag (same pattern as `render_tree`) and uses `_display_value()` for all value cells — showing `[redacted]` unless `--decrypt` was passed.
- Also wraps all diff table value cells in `Text()` objects instead of raw strings, fixing a silent Rich markup-parsing bug where `[redacted]` was being interpreted as a markup tag and stripped from output entirely.

## What was leaking

| Surface | Before | After |
|---|---|---|
| Tree output (`--show-values`) | Fixed in v0.2.0 | Fixed |
| Diff table (`--show-values`) | **Leaked ciphertext** | `[redacted]` |
| JSON output | Already guarded by `_redact_value()` | No change |
| Copy plan table | No values shown | No change |

## Test plan

- [x] `test_diff_redacts_secure_strings_without_decrypt` — all 4 value slots (removed, added, old/new changed) show `[redacted]`; no ciphertext leaks
- [x] `test_diff_shows_secure_string_values_when_decrypted` — values visible when `decrypt=True`
- [x] All 106 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)