### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ssmtree"
-version = "0.2.0"
+version = "0.3.0"
 description = "Render AWS SSM Parameter Store as a colorized terminal tree"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/ssmtree/__init__.py
+++ b/src/ssmtree/__init__.py
@@ -1,3 +1,3 @@
 """ssmtree — Render AWS SSM Parameter Store as a colorized terminal tree."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
## Summary
- Bumps `__version__` in `src/ssmtree/__init__.py` to `0.3.0`
- Bumps `version` in `pyproject.toml` to `0.3.0`

Ships the SecureString redaction fix in `render_diff` (merged via #10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)