### PR TITLE
feat: show values by default; SecureStrings always show [redacted]

### DIFF
--- a/src/ssmtree/cli.py
+++ b/src/ssmtree/cli.py
@@ -104,8 +104,8 @@ class _DefaultPathGroup(click.Group):
 )
 @click.option(
     "--show-values/--hide-values",
-    default=False,
-    help="Show or hide parameter values (default: hide).",
+    default=True,
+    help="Show or hide parameter values (default: show; SecureStrings shown as [redacted]).",
 )
 @click.option(
     "--output",
@@ -137,7 +137,8 @@ def main(
     \b
     Examples:
       ssmtree /app/prod
-      ssmtree --decrypt --show-values /app/prod
+      ssmtree --decrypt /app/prod
+      ssmtree --hide-values /app/prod
       ssmtree --filter "*db*" /app
       ssmtree --output json /app/prod
       ssmtree --output json --include-secrets /app/prod
@@ -191,8 +192,8 @@ def main(
 @click.option("--region", default=None, help="AWS region.")
 @click.option(
     "--show-values/--hide-values",
-    default=False,
-    help="Show or hide parameter values in diff (default: hide).",
+    default=True,
+    help="Show or hide parameter values in diff (default: show; SecureStrings are [redacted]).",
 )
 @click.option(
     "--include-secrets",
@@ -221,7 +222,7 @@ def diff_cmd(
     \b
     Examples:
       ssmtree diff /app/prod /app/staging
-      ssmtree diff --decrypt --show-values /app/prod /app/staging
+      ssmtree diff --decrypt /app/prod /app/staging
       ssmtree diff --decrypt --output json --include-secrets /app/prod /app/staging
     """
     _validate_path(path1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,11 +90,18 @@ class TestMainCommand:
         assert len(secure) == 1
         assert secure[0]["value"] == "FAKE-test-password"
 
-    def test_values_hidden_by_default(self, runner):
+    def test_values_shown_by_default(self, runner):
         with patch("ssmtree.cli.fetch_parameters", return_value=PROD_PARAMS):
             result = runner.invoke(main, ["/app/prod"])
         assert result.exit_code == 0
-        assert "prod-host" not in result.output
+        assert "prod-host" in result.output
+
+    def test_secure_string_redacted_by_default(self, runner):
+        with patch("ssmtree.cli.fetch_parameters", return_value=PROD_PARAMS):
+            result = runner.invoke(main, ["/app/prod"])
+        assert result.exit_code == 0
+        assert "[redacted]" in result.output
+        assert "FAKE-test-password" not in result.output
 
     def test_show_values(self, runner):
         with patch("ssmtree.cli.fetch_parameters", return_value=PROD_PARAMS):


### PR DESCRIPTION
## Summary
- `--show-values` now defaults to `True` for both `ssmtree` and `ssmtree diff`
- `--decrypt` alone now works as expected — values are visible without requiring a separate `--show-values` flag
- SecureString parameters always display as `[redacted]` unless `--decrypt` is passed
- `--hide-values` remains available to suppress all values

## Behaviour change

| Command | Before | After |
|---|---|---|
| `ssmtree /path` | No values shown | Values shown; SecureStrings → `[redacted]` |
| `ssmtree --decrypt /path` | No values shown | Values shown including decrypted SecureStrings |
| `ssmtree --hide-values /path` | No values shown | No values shown (unchanged) |

## Test plan
- [x] `test_values_shown_by_default` — plain String values appear without any flag
- [x] `test_secure_string_redacted_by_default` — SecureString shows `[redacted]`, not the ciphertext
- [x] `test_hide_values` — `--hide-values` still suppresses all values
- [x] `test_show_values` — `--show-values` still works explicitly
- [x] 107 tests passing, `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)