### PR TITLE
docs: update README for v0.3.x features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ssmtree
 
 [![CI](https://github.com/Specter099/ssmtree/actions/workflows/ci.yml/badge.svg)](https://github.com/Specter099/ssmtree/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/ssmtree)](https://pypi.org/project/ssmtree/)
 ![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)
 ![License: MIT](https://img.shields.io/badge/license-MIT-green)
 
@@ -12,35 +13,50 @@ Render AWS SSM Parameter Store as a colorized terminal tree. Browse, diff, and c
 - **Diff** — Compare parameters between two namespaces side by side
 - **Copy** — Copy parameters from one namespace to another with dry-run support
 - **Glob filtering** — Filter parameters with glob patterns to focus on what matters
-- **JSON output** — Export parameter trees as JSON for scripting and automation
+- **JSON output** — Export parameter trees or diffs as JSON for scripting and automation
 - **Decrypt support** — Decrypt SecureString parameters inline with optional KMS key re-encryption
+- **SecureString safety** — SecureString values shown as `[redacted]` by default; use `--decrypt` to reveal them
+- **Leaf parameter support** — Query a single leaf parameter directly (e.g. `ssmtree /app/db/password`)
 
 ## Installation
 
 ```bash
-pip install .
+pip install ssmtree
 ```
 
 For development:
 
 ```bash
+git clone https://github.com/Specter099/ssmtree.git
+cd ssmtree
+python -m venv .venv
+source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
 ## Quick Start
 
 ```bash
-# Basic tree view
+# Browse all parameters under a prefix
 ssmtree /app/prod
 
-# With decryption
+# Query a single leaf parameter
+ssmtree /app/prod/db/password
+
+# Decrypt SecureString values (shown as [redacted] by default)
 ssmtree --decrypt /app/prod
 
-# Filter parameters with a glob pattern
+# Hide all values entirely
+ssmtree --hide-values /app/prod
+
+# Filter with a glob pattern
 ssmtree --filter "*db*" /app
 
-# JSON output
+# JSON output (SecureStrings redacted by default)
 ssmtree --output json /app/prod
+
+# JSON output with SecureString values included
+ssmtree --decrypt --output json --include-secrets /app/prod
 ```
 
 ## Commands
@@ -50,7 +66,17 @@ ssmtree --output json /app/prod
 Compare parameters between two namespaces:
 
 ```bash
+# Table diff (default)
 ssmtree diff /app/prod /app/staging
+
+# With decryption
+ssmtree diff --decrypt /app/prod /app/staging
+
+# JSON diff output
+ssmtree diff --output json /app/prod /app/staging
+
+# JSON diff with SecureString values included
+ssmtree diff --decrypt --output json --include-secrets /app/prod /app/staging
 ```
 
 ### copy
@@ -61,19 +87,37 @@ Copy parameters from one namespace to another:
 # Preview what would be copied
 ssmtree copy --dry-run /app/prod /app/staging
 
-# Copy with overwrite, decryption, and re-encryption under a new KMS key
-ssmtree copy --overwrite --decrypt --kms-key-id alias/my-key /app/prod /app/staging
+# Copy (prompts for confirmation)
+ssmtree copy /app/prod /app/staging
+
+# Copy with overwrite, skip confirmation
+ssmtree copy --yes --overwrite /app/prod /app/staging
+
+# Copy with decryption and re-encryption under a new KMS key
+ssmtree copy --decrypt --kms-key-id alias/my-key /app/prod /app/staging
 ```
+
+## Options
+
+| Option | Commands | Description |
+|--------|----------|-------------|
+| `--decrypt` / `-d` | all | Decrypt SecureString values |
+| `--profile` | all | AWS named profile to use |
+| `--region` | all | AWS region override |
+| `--show-values` / `--hide-values` | `main`, `diff` | Show or hide parameter values (default: show) |
+| `--filter PATTERN` / `-f` | `main` | Glob filter on parameter paths |
+| `--output` | `main`, `diff` | Output format: `tree`/`table` (default) or `json` |
+| `--include-secrets` | `main`, `diff` | Include SecureString values in JSON output |
+| `--overwrite` / `--no-overwrite` | `copy` | Overwrite existing destination parameters |
+| `--dry-run` | `copy` | Show what would be copied without writing |
+| `--kms-key-id` | `copy` | KMS key for SecureString parameters at destination |
+| `--yes` / `-y` | `copy` | Skip confirmation prompt |
 
 ## Development
 
 ```bash
-git clone https://github.com/Specter099/ssmtree.git
-cd ssmtree
-python -m venv .venv
-source .venv/bin/activate
-pip install -e ".[dev]"
-pytest
+pytest          # run tests
+ruff check .    # lint
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- Add PyPI version badge and `pip install ssmtree` install instruction
- Document SecureString `[redacted]` default behavior (new in v0.3.0)
- Add `--hide-values`, `--include-secrets`, and leaf parameter query examples
- Expand `diff` examples to cover `--output json` and `--include-secrets`
- Expand `copy` examples to cover `--yes` flag
- Add full options reference table covering all commands

## Test plan
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)