### PR TITLE
fix: parse options placed after PATH positional argument

### DIFF
--- a/src/ssmtree/cli.py
+++ b/src/ssmtree/cli.py
@@ -82,7 +82,10 @@ class _DefaultPathGroup(click.Group):
         else:
             # PATH mode: let the option parser consume group options, then
             # collect the remaining positional (PATH) in ctx.args.
+            # allow_interspersed_args=True lets options appear after the PATH
+            # positional (e.g. `ssmtree /app/prod --decrypt`).
             ctx.allow_extra_args = True
+            ctx.allow_interspersed_args = True
             rest = click.Command.parse_args(self, ctx, args)
             ctx._protected_args = []
             ctx.args = rest


### PR DESCRIPTION
## Summary

- `ssmtree /test --decrypt` was silently ignoring `--decrypt`, always showing `[redacted]`
- Root cause: Click `Group` has `allow_interspersed_args=False` by default, so the option parser stops at the first non-option token (`/test`) and leaves subsequent flags unparsed
- Fix: set `ctx.allow_interspersed_args = True` in the PATH mode branch of `_DefaultPathGroup.parse_args` before calling `parse_args` — Click's `OptionParser` reads this from the context

## Test plan
- [ ] `test_decrypt_after_path_is_parsed` — verifies `decrypt=True` is passed to `fetch_parameters`
- [ ] `test_decrypt_after_path_reveals_secure_string` — verifies no `[redacted]` in output
- [ ] `test_hide_values_after_path_is_parsed` — verifies `--hide-values` after path works
- [ ] `test_filter_after_path_is_parsed` — verifies `--filter` after path works
- [ ] All 115 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)