### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ssmtree"
-version = "0.3.1"
+version = "0.3.2"
 description = "Render AWS SSM Parameter Store as a colorized terminal tree"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/ssmtree/__init__.py
+++ b/src/ssmtree/__init__.py
@@ -1,3 +1,3 @@
 """ssmtree — Render AWS SSM Parameter Store as a colorized terminal tree."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
Bump version to 0.3.2 for release.

Fixes included in this release:
- Fix options placed after PATH positional argument being silently ignored (e.g., `ssmtree /path --decrypt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)