### PR TITLE
Replace hardcoded S3 bucket with repository variable

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Upload to S3
         run: |
           aws s3 cp "${{ steps.vars.outputs.filename }}" \
-            "s3://github-repo-backup-1b114b0d7fd4/${{ steps.vars.outputs.s3-key }}"
+            "s3://${{ vars.BACKUP_S3_BUCKET }}/${{ steps.vars.outputs.s3-key }}"
 
       - name: Write job summary
         run: |
@@ -54,4 +54,4 @@ jobs:
           echo "| Commit | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Archive | \`${{ steps.vars.outputs.filename }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Size | $ARCHIVE_SIZE |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| S3 URI | \`s3://github-repo-backup-1b114b0d7fd4/${{ steps.vars.outputs.s3-key }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| S3 URI | \`s3://${{ vars.BACKUP_S3_BUCKET }}/${{ steps.vars.outputs.s3-key }}\` |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Replaces hardcoded `github-repo-backup-1b114b0d7fd4` bucket name with `${{ vars.BACKUP_S3_BUCKET }}` in the backup workflow
- Aligns with the pattern used in the `.github` repo for consistency
- `BACKUP_S3_BUCKET` repo variable has been set

## Test plan
- [ ] Merge PR and trigger backup workflow manually to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)