### PR TITLE
fix: upgrade pip and ignore unfixed CVE in pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,10 @@ jobs:
         run: ruff check src tests
 
       - name: Audit dependencies
-        # CVE-2026-4539: pygments (transitive via rich); no fix as of 2026-03-24
-        # CVE-2026-3219, CVE-2026-6357: pip itself; upgrade pip when patched
-        run: pip install pip-audit && pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357
+        run: |
+          pip install --upgrade pip
+          pip install pip-audit
+          pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219
 
       - name: Run tests
         run: pytest --cov=ssmtree --cov-report=term-missing


### PR DESCRIPTION
## Summary

- pip 26.0.1 (pre-installed on GitHub runners) has two CVEs flagged by pip-audit:
  - **CVE-2026-6357**: fixed in pip 26.1 — resolved by adding `pip install --upgrade pip` before running pip-audit (removed `--ignore-vuln CVE-2026-6357` since upgrading fixes it)
  - **CVE-2026-3219**: no fix available yet — kept `--ignore-vuln CVE-2026-3219` until a patch is released
- Keeps existing `--ignore-vuln CVE-2026-4539` (pygments, no fix yet)

## Test plan

- [ ] CI pipeline passes on this PR (pip-audit no longer exits non-zero)
- [ ] Verify `pip install --upgrade pip` pulls pip >= 26.1
- [ ] Verify `--ignore-vuln CVE-2026-3219` suppresses the unfixed CVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)